### PR TITLE
Remove maximum dependency versions

### DIFF
--- a/rollie.gemspec
+++ b/rollie.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.require_paths = ["lib"]
 
-  s.add_dependency "redis", "~> 3.2", ">= 3.2.1"
-  s.add_dependency "redis-namespace", "~> 1.5", ">= 1.5.2"
-  s.add_dependency "connection_pool", "~> 2.2", ">= 2.2.0"
+  s.add_dependency "redis", ">= 3.2.1"
+  s.add_dependency "redis-namespace", ">= 1.5.2"
+  s.add_dependency "connection_pool", ">= 2.2.0"
 end


### PR DESCRIPTION
It is common practice to use only minimum gem versions in gemspecs to
allow the gem to be "self maintaining" to some degree. We can apply a
maximum versions if a known incompatibility is found.

Allows rollie to be compatible with redis gem version 4 or future
versions of redis-namespace or connection_pool.